### PR TITLE
add catalog-info file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @nandosousafr
+* @ResultadosDigitais/devtools

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: elastic-opencensus-exporter-go
+  description: O pacote escensus fornece um exportador para enviar estatísticas do Opencensus (ainda não implementadas) e rastreamentos para o Elastic.
+  annotations:
+    github.com/project-slug: ResultadosDigitais/elastic-opencensus-exporter-go
+spec:
+  type: library
+  owner: devtools
+  lifecycle: production


### PR DESCRIPTION
Contexto

Estamos mapeando os componentes do plataform para dentro do Backstage e por isso precisamos deste arquivo yaml no mesmo diretório do componente para que ele seja refletido no Backstage.

É possível consultar mais detalhes deste mapeamento aqui: https://github.com/ResultadosDigitais/designdoc/blob/master/enablers/devtools/fonte-da-verdade-artefatos.md